### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,15 +48,15 @@ pypi-alias
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/pypi-alias
 
-.. |wheel| image:: https://pypip.in/wheel/pypi-alias/badge.svg?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/pypi-alias.svg?style=flat
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/pypi-alias
 
-.. |supported-versions| image:: https://pypip.in/py_versions/pypi-alias/badge.svg?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/pypi-alias.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/pypi-alias
 
-.. |supported-implementations| image:: https://pypip.in/implementation/pypi-alias/badge.svg?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/pypi-alias.svg?style=flat
     :alt: Supported imlementations
     :target: https://pypi.python.org/pypi/pypi-alias
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pypi-alias))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pypi-alias`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.