### PR TITLE
Fixes for Python 3.6+

### DIFF
--- a/src/pypi_alias/__main__.py
+++ b/src/pypi_alias/__main__.py
@@ -9,7 +9,7 @@ import tempfile
 
 
 def run_command(params):
-    output = subprocess.check_output(params)
+    output = subprocess.check_output(params, encoding="utf-8")
     return output.strip()
 
 

--- a/src/pypi_alias/__main__.py
+++ b/src/pypi_alias/__main__.py
@@ -8,19 +8,24 @@ import sys
 import tempfile
 
 
+def run_command(params):
+    output = subprocess.check_output(params)
+    return output.strip()
+
+
 def main():
-    name = subprocess.check_output(['python', 'setup.py', '--name']).strip()
+    name = run_command(['python', 'setup.py', '--name'])
     url = "https://pypi.python.org/pypi/%s/" % name
-    description = subprocess.check_output(['python', 'setup.py', '--description']).strip()
+    description = run_command(['python', 'setup.py', '--description'])
     assert 'python' not in name
     if len(sys.argv) == 1:
         print("Usage: %s alias [setup.py arguments]" % sys.argv[0], file=sys.stderr)
         sys.exit(1)
     alias = sys.argv[1]
-    author = subprocess.check_output(['python', 'setup.py', '--author']).strip()
-    author_email = subprocess.check_output(['python', 'setup.py', '--author-email']).strip()
-    maintainer = subprocess.check_output(['python', 'setup.py', '--maintainer']).strip()
-    maintainer_email = subprocess.check_output(['python', 'setup.py', '--maintainer-email']).strip()
+    author = run_command(['python', 'setup.py', '--author'])
+    author_email = run_command(['python', 'setup.py', '--author-email'])
+    maintainer = run_command(['python', 'setup.py', '--maintainer'])
+    maintainer_email = run_command(['python', 'setup.py', '--maintainer-email'])
 
     try:
         path = tempfile.mkdtemp()

--- a/src/pypi_alias/__main__.py
+++ b/src/pypi_alias/__main__.py
@@ -30,12 +30,12 @@ def main():
     try:
         path = tempfile.mkdtemp()
         os.chdir(path)
-        with open(os.path.join(path, 'setup.cfg'), 'wb') as fh:
-            fh.write(b"""[bdist_wheel]
+        with open(os.path.join(path, 'setup.cfg'), 'w', encoding="utf-8") as fh:
+            fh.write("""[bdist_wheel]
 universal = 1
 """)
-        with open(os.path.join(path, 'setup.py'), 'wb') as fh:
-            fh.write(b"""# encoding: utf8
+        with open(os.path.join(path, 'setup.py'), 'w', encoding="utf-8") as fh:
+            fh.write("""# encoding: utf8
 
 from setuptools import setup
 


### PR DESCRIPTION
All changes seem to be related to IO commands needing an encoding set. 

I tested this with Python 3.9. I think this might only work for Python 3.6, when the encoding flag was added to check_output, hope that's OK.
